### PR TITLE
Fix issue where data counter would write a 0 on the first byte, add reset canary

### DIFF
--- a/PSP-Main-Code.ino
+++ b/PSP-Main-Code.ino
@@ -27,7 +27,7 @@
 
 unsigned int currentAddress = 0; // Current address for both EEPROMs
 unsigned int logAddress = 65534; // Location where last address will be logged
-int counter = 0;
+int counter = 63;                // Counter initialized to 63. If a 63 is seen while reading out the data, reset occured.
 unsigned int data[DATA_SIZE]; // Data array 
 
 unsigned long timeOfLastSensorRead;
@@ -85,8 +85,8 @@ void loop() {
         while (true); // Stop further execution
     }
 
-    //iterate counter and reset at 63
-    counter = (counter + 1) % 64;
+    //Count from 1 to 62 (inclusive).
+    counter = (counter % 62) + 1;
     //Move to next address
     currentAddress += 4;
 


### PR DESCRIPTION
- The old counter would start at 0 and go up to 63, then reset to 0. This meant there was a 1/64 chance of data being overwritten on a power reset if the analog sensor was also reading out less than 256.
- The old counter had a 1/64 chance of "missing" a reset (if a reset happened when the counter was at 63, the next value written after the reset would be 0, which would match the pattern).

New counter fixes both issues by starting at 63 (meaning if a 63 is seen, the board is writing for the first time on that power up). It then counts up starting from 2 to 62 and resets at 1 and counts as normal from this point on, counting up to 62 then resetting to 1.

Old sequence:
0, 1, 2, 3, ..., 61, 62, 63, 0, 1, 2, ...., 61, 62, 63, 0, 1, 2, ...

New sequence:
63, 2, 3, 4, 5, ...,  59, 60, 61, 62, 1, 2, 3, ... , 59, 60, 61, 62, 1, 2, ...